### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,6 @@
 name: CI
+permissions:
+  contents: read
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Potential fix for [https://github.com/GalacticDynamics/zeroth/security/code-scanning/5](https://github.com/GalacticDynamics/zeroth/security/code-scanning/5)

To fix the error, add a `permissions` key to the root of the workflow file `.github/workflows/ci.yml`. This ensures that all jobs use least-privilege settings for `GITHUB_TOKEN`. Since the shown jobs do not require more than read access (not writing to the repo or manipulating PRs), set `permissions: contents: read` immediately after the `name` property (line 1). No changes are necessary at the job level unless some jobs require additional permissions. This fix restricts the default token permissions for all jobs in this workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
