### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -23,6 +23,8 @@ jobs:
   dist:
     name: Distribution build
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0


### PR DESCRIPTION
Potential fix for [https://github.com/GalacticDynamics/zeroth/security/code-scanning/4](https://github.com/GalacticDynamics/zeroth/security/code-scanning/4)

To fix the problem, explicitly declare a `permissions` block for the `dist` job assigning it the least privilege required. The job presently only checks out code, builds, and inspects a Python package (using the `actions/checkout` and `hynek/build-and-inspect-python-package` actions); neither action requires anything beyond read access to code. Therefore, set `permissions: { contents: read }` in the `dist` job definition (immediately under `runs-on: ubuntu-latest`). No method or import additions are necessary—just a modification to the YAML file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
